### PR TITLE
KVS ベースで証明書を動的にロードし配信する

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ngx_mruby でローカル環境で動的証明書配信を試験する。
 
 以下論文の p4 にある設定例を参考に検証する。
+
 [高集積マルチテナントWebサーバの大規模証明書管理](https://rand.pepabo.com/papers/iot37-proceeding-matsumotory.pdf)
 
 
@@ -12,6 +13,7 @@ ngx_mruby でローカル環境で動的証明書配信を試験する。
 ## 設定例1. 証明書ファイルを動的読み込み
 
 ```
+http {
     server {
         listen 443 ssl;
         server_name _;
@@ -25,28 +27,42 @@ ngx_mruby でローカル環境で動的証明書配信を試験する。
             ssl.certificate_key = "/etc/ssl/certs/#{host}.key"
         ';
     }
+}
 ```
 
-証明書ファイルが増えると起動が遅くなるデメリットがある為、以下「設定例2」を検証する。
+証明書ファイルが増えると起動が遅くなるデメリットがある為、
+以下「設定例2. KV ベースで証明書を動的読み込み」を検証する。
 
 ## 設定例2. KVS ベースで証明書を動的読み込み
 
 ```
-server {
-    listen 443 ssl;
-    server_name _;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers HIGH:!aNULL:!MD5;
-    ssl_certificate /path/to/dummy.crt;
-    ssl_certificate_key /path/to/dummy.key;
-    mruby_ssl_handshake_handler_code ’
-        ssl = Nginx::SSL.new
-        host = ssl.servername
-        redis = Redis.new "127.0.0.1", 6379
-        ssl.certificate_data = redis["#{host}.crt"]
-        ssl.certificate_key_data = redis["#{host}.key"]
-    ’;
+env REDIS_HOST;
+
+http {
+  server {
+      listen 443 ssl;
+      server_name _;
+      ssl_certificate /path/to/dummy.crt;
+      ssl_certificate_key /path/to/dummy.key;
+      mruby_ssl_handshake_handler_code '
+          ssl = Nginx::SSL.new
+          host = ssl.servername
+          redis = Redis.new ENV["REDIS_HOST"], 6379
+          crt, key = redis.hmget host, "crt", "key"
+          ssl.certificate_data = crt
+          ssl.certificate_key_data = key
+      ';
+  }
 }
+```
+
+* Redis にデータ登録
+
+```
+$ docker-compose exec redis \
+  redis-cli hmset localhost crt "$(cat docker/certs/localhost.crt)" \
+  key "$(cat docker/certs/localhost.key)"
+$ docker-compose exec redis redis-cli hmget localhost crt key
 ```
 
 ## Findings
@@ -58,4 +74,3 @@ server {
 * デバッグ等で出力したい場合は logger を使おう！
   - `Nginx.errlogger Nginx::LOG_INFO, "foo"`
   - ssl_handler 内では `Nginx::SSL.errlogger Nginx::LOG_NOTICE, "foo"`
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,17 @@ services:
     ports:
       - 80:80
       - 443:443
+    environment:
+      REDIS_HOST: "redis"
+    links:
+      - redis:redis
+
+  redis:
+    image: redis:alpine
+    ports:
+      - ${REDIS_PORT:-6379}:6379
+    volumes:
+       - redis:/data
+
+volumes:
+  redis: {}

--- a/docker/conf/nginx.conf.file_base
+++ b/docker/conf/nginx.conf.file_base
@@ -52,10 +52,8 @@ http {
         mruby_ssl_handshake_handler_code '
             ssl = Nginx::SSL.new
             host = ssl.servername
-            redis = Redis.new ENV["REDIS_HOST"], 6379
-            crt, key = redis.hmget host, "crt", "key"
-            ssl.certificate_data = crt
-            ssl.certificate_key_data = key
+            ssl.certificate = "/etc/ssl/certs/#{host}.crt"
+            ssl.certificate_key = "/etc/ssl/certs/#{host}.key"
         ';
     }
 }


### PR DESCRIPTION
簡易的な KVS ベースの動的読み込み配信が実現できた実例として残しておく。

尚、証明書ファイルの動的読み込みの nginx.conf は nginx.conf.file_base として残しておく。

Redis にデータ登録方法を記載しておく。