### PR TITLE
nginx_build で利用するファイルの格納ディレクトリを同一にする

### DIFF
--- a/build/build_config.rb
+++ b/build/build_config.rb
@@ -4,9 +4,7 @@ MRuby::Build.new do |conf|
 
   conf.gembox 'full-core'
 
-  #
   # Recommended for ngx_mruby
-  #
   conf.gem :github => 'iij/mruby-env'
   conf.gem :github => 'iij/mruby-dir'
   conf.gem :github => 'iij/mruby-digest'

--- a/build/modules3rd.ini
+++ b/build/modules3rd.ini
@@ -7,4 +7,4 @@ rev=2.3
 form=git
 url=https://github.com/matsumotory/ngx_mruby.git
 rev=v2.2.3
-shprov=/build/mruby/wrap_build.sh
+shprov=/build/wrap_build.sh

--- a/build/wrap_build.sh
+++ b/build/wrap_build.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-/bin/cp -f /build/mruby/build_config.rb ./
+/bin/cp -f /build/build_config.rb ./
 ./configure --with-ngx-src-root=../nginx-$NGINX_VER
 
 make build_mruby -j 2


### PR DESCRIPTION
* nginx_build でのビルドで利用するファイルの格納ディクレトリを同一にする。
* crt, key ファイル格納ディレクトリを空で用意する