### PR TITLE
nginx 80 port でヘルスチェック追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker/certs/*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build test](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/build_test.yml/badge.svg)](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/build_test.yml)
+
 ## 目的
 ngx_mruby でローカル環境で動的証明書配信を試験する。
 
@@ -11,10 +13,11 @@ ngx_mruby でローカル環境で動的証明書配信を試験する。
 * docker/certs/ ディレクトリ以下に crt, key ファイルを生成する。
 
 ```console
+sh crt.sh dummy
 sh crt.sh localhost
 ```
 
-localhost.crt を git に push すると git さんに怒られるので生成お願いします。
+.crt を git に push すると git さんに怒られるので生成お願いします。
 
 ## 設定例1. 証明書ファイルを動的読み込み
 
@@ -97,6 +100,31 @@ end
 ※ alpine で mattn/mruby-mysql 使用するには `apk add mariadb-connector-c-dev` が必要です。
 ※ build_config.rb で `conf.gem :github => 'mattn/mruby-mysql'` の設定をしている。
 
+## ヘルスチェック
+
+AWS ELB を想定したヘルスチェックです。
+User-Agent に ELB-HealthChecker からのアクセスの場合は、ヘルスチェックを通す。
+
+```console
+$ curl -v -H "User-Agent: ELB-HealthChecker" "http://localhost/healthcheck"
+
+...
+> User-Agent: ELB-HealthChecker
+>
+< HTTP/1.1 200 OK
+...
+```
+
+`User-Agent: ELB-HealthChecker` がない場合、443 へリダイレクトする。
+
+```console
+$ curl -v "http://localhost/healthcheck"
+
+...
+< HTTP/1.1 301 Moved Permanently
+...
+```
+
 ## Findings
 
 * mruby_init_worker で `Nginx.echo` は使用できない。
@@ -106,3 +134,4 @@ end
 * デバッグ等で出力したい場合は logger を使おう！
   - `Nginx.errlogger Nginx::LOG_INFO, "foo"`
   - ssl_handler 内では `Nginx::SSL.errlogger Nginx::LOG_NOTICE, "foo"`
+* [通常の ruby の gem](rubygems.org) は利用できない。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,20 +15,22 @@ services:
       DB_NAME: tmp
     links:
       - redis:redis
+    volumes:
+      - ./docker/certs:/etc/ssl/certs
 
   redis:
     image: redis:alpine
     ports:
       - ${REDIS_PORT:-6379}:6379
     volumes:
-       - redis:/data
+      - redis:/data
 
   db:
     image: mysql:5.7.29
     ports:
       - ${DB_PORT:-3306}:3306
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     volumes:
       - ./initial.sql:/docker-entrypoint-initdb.d/initial.sql
       - db:/var/lib/mysql

--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -4,7 +4,7 @@ env DATABASE_URL;
 env DB_NAME;
 
 user daemon;
-worker_processes 1;
+worker_processes auto;
 error_log stderr;
 
 events {
@@ -12,6 +12,21 @@ events {
 }
 
 http {
+    # HTTPヘッダにnginxのバージョン情報を付加しないようにする
+    server_tokens off;
+
+    # クライアントにレスポンスする際にコンテンツがどのようなものか知らせる必要があり
+    # MINEタイプと拡張子情報を読み込む必要がる
+    include      mime.types;
+    default_type application/octet-stream;
+
+    # コンテンツの読込みとクライアントのレスポンス送信にsendfileシステムコールを使用する
+    # カーネル空間での処理となるので処理が改善される
+    sendfile on;
+
+    # レスポンスヘッダとファイル内容を同時に送信しパケットを最小化する(sendfileを使用している時にのみ有効)
+    tcp_nopush on;
+
     log_format ltsv 'domain:$host\t'
                     'host:$remote_addr\t'
                     'user:$remote_user\t'
@@ -37,10 +52,36 @@ http {
 
     server {
         listen 80;
-
-        location /healthcheck {
-            mruby_content_handler_code 'Nginx.echo "server ip: #{Nginx::Connection.new.local_ip}: hello ngx_mruby world."';
+        listen [::]:80;
+        # ELB到達がHTTPだった場合、HTTPにリダイレクトする
+        if ($http_x_forwarded_proto != https) {
+            set $to_https  A;
         }
+        if ($http_user_agent !~* ELB-HealthChecker) {
+            set $to_https  "${to_https}B";
+            set $direct_ip A;
+        }
+        if ($to_https = AB) {
+            return 301 https://$host$request_uri;
+        }
+
+        location / {
+            if ($request_uri ~ ^/healthcheck) {
+                return 200;
+            }
+        }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name _;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers 'ECDHE+AESGCM:DHE+aRSA+AESGCM:ECDHE+AESCCM:DHE+aRSA+AESCCM:+AES256:ECDHE+CHACHA20:DHE+aRSA+CHACHA20:+DHE:ECDHE+AES128:ECDHE+CAMELLIA128:ECDHE+AES:ECDHE+CAMELLIA:+ECDHE+SHA:DHE+aRSA+AES128:DHE+aRSA+CAMELLIA128:DHE+aRSA+AES:DHE+aRSA+CAMELLIA:+DHE+aRSA+SHA';
+        ssl_certificate /etc/ssl/certs/dummy.crt;
+        ssl_certificate_key /etc/ssl/certs/dummy.key;
+
+        mruby_ssl_handshake_handler /usr/local/nginx/hook/ssl_handshake_handler.rb cache;
 
         location /mysql-test {
             mruby_content_handler /usr/local/nginx/hook/mysql_test.rb;
@@ -50,20 +91,5 @@ http {
             root /usr/local/nginx/html;
             index index.html;
         }
-    }
-
-    server {
-        listen 443 ssl;
-        server_name _;
-        ssl_certificate /etc/ssl/certs/dummy.crt;
-        ssl_certificate_key /etc/ssl/certs/dummy.key;
-        mruby_ssl_handshake_handler_code '
-            ssl = Nginx::SSL.new
-            host = ssl.servername
-            redis = Redis.new ENV["REDIS_HOST"], 6379
-            crt, key = redis.hmget host, "crt", "key"
-            ssl.certificate_data = crt
-            ssl.certificate_key_data = key
-        ';
     }
 }

--- a/docker/hook/ssl_handshake_handler.rb
+++ b/docker/hook/ssl_handshake_handler.rb
@@ -1,0 +1,24 @@
+redis = Userdata.new("redis_#{Process.pid}").redis_connection
+
+# NOTE: redis へのコネクションが切断されている場合、接続する
+if redis == nil then
+    Nginx.errlogger Nginx::LOG_INFO, "trying to connect to redis"
+    redis_url = ENV["REDIS_URL"]
+    redis_host, redis_port = redis_url[/^redis?:\/\/(.+)/, 1].split(":")
+    redis = Redis.new redis_host, redis_port.to_i
+    Userdata.new("redis_#{Process.pid}").redis_connection = redis
+end
+
+ssl = Nginx::SSL.new
+Nginx::SSL.errlogger Nginx::LOG_NOTICE, "Servername is #{ssl.servername}"
+crt, key = redis.hmget ssl.servername, 'crt', 'key'
+
+if crt.empty? || key.empty? then
+    # TODO: redis に登録されていない場合、DB を参照する
+    #       DB に登録されていない場合は、エラー発生させ、処理を停止させる
+
+    Nginx.return Nginx::HTTP_NOT_FOUND
+end
+
+ssl.certificate_data = crt
+ssl.certificate_key_data = key


### PR DESCRIPTION
* AWS ELB を利用することを想定し、ELB User-Agent の場合は許可する。
  - それ以外は 443 へ 301 リダイレクトする。

## nginx 各種設定

* worker_processes auto; ... workerプロセスの数をCPUコア（スレッド）数で決定する
* server_tokens off; ... HTTPヘッダにnginxのバージョン情報を付加しないようにする
* クライアントにレスポンスする際にコンテンツがどのようなものか知らせる必要があり、MINEタイプと拡張子情報を読み込む必要がる。
```
    include       mime.types;
    default_type  application/octet-stream;
```

* sendfile on; ... コンテンツの読込みとクライアントのレスポンス送信にsendfileシステムコールを使用する。カーネル空間での処理となるので処理が改善される。
* tcp_nopush on; ...レスポンスヘッダとファイル内容を同時に送信しパケットを最小化する(sendfileを使用している時にのみ有効)

* ssl_protocols TLSv1.2 TLSv1.3; ... 2021年3月現在、 TLSv1.2, 1.3 が利用推奨。
* ssl_prefer_server_chiphers on; ... サーバ指定の暗号化スイートを優先する。
* ssl_ciphers ...  IPA のガイドラインに掲載されている推奨セキュリティ設定の暗号スイートを設定している。