### PR TITLE
http → https リダイレクト処理を削除

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -53,17 +53,6 @@ http {
     server {
         listen 80;
         listen [::]:80;
-        # ELB到達がHTTPだった場合、HTTPにリダイレクトする
-        if ($http_x_forwarded_proto != https) {
-            set $to_https  A;
-        }
-        if ($http_user_agent !~* ELB-HealthChecker) {
-            set $to_https  "${to_https}B";
-            set $direct_ip A;
-        }
-        if ($to_https = AB) {
-            return 301 https://$host$request_uri;
-        }
 
         location / {
             if ($request_uri ~ ^/healthcheck) {


### PR DESCRIPTION
NLB + ECS で正しく動作しなかった為、一旦削除する。