### PR TITLE
nginx.conf の不要な変数を削除する

### DIFF
--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -1,4 +1,3 @@
-env REDIS_HOST;
 env REDIS_URL;
 env DATABASE_URL;
 env DB_NAME;
@@ -59,7 +58,6 @@ http {
         }
         if ($http_user_agent !~* ELB-HealthChecker) {
             set $to_https  "${to_https}B";
-            set $direct_ip A;
         }
         if ($to_https = AB) {
             return 301 https://$host$request_uri;


### PR DESCRIPTION
利用していない変数 REDIS_HOST を削除する。
利用していない direct_ip を削除する。元々、直 IP を禁止する処理で利用しようかと思っていたが、
複数ドメイン名で扱う前提の為、それが難しかった。