### PR TITLE
README に開発手順を追記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,35 @@ ngx_mruby でローカル環境で動的証明書配信を試験する。
 
 Dockerfile ビルド時に dummy.crt, dummy.key が生成され、イメージに含まれる。
 
+## 開発環境の構築
+
+### 1. 環境に必要なツールのインストール
+
+- [dip](https://github.com/bibendi/dip)
+
+### 2. プロビジョニング
+
+```console
+dip provision
+```
+
+開発で使用する `*.localhost` ワイルドカード証明書の localhost.crt, localhost.key を作成し redis に登録します。
+
+### 3. /etc/hosts 設定
+
+```
+127.0.0.1 aaa.localhost bbb.localhost
+```
+
+aaa.localhost, bbb.localhost を 127.0.0.1 に向ける。
+証明書の動的配信の動作確認用に設定しています。
+
+### 4. serverの起動
+
+```console
+dc up -d
+```
+
 ## 設定例1. 証明書ファイルを動的読み込み
 
 ```
@@ -61,16 +90,6 @@ http {
 * [matsumoto-r/mruby-redis](https://github.com/matsumoto-r/mruby-redis) は TLS サポートしていない。
 * `REDIS_URL = redis://<redis host>:6379` の様にスキーマ込みで渡したい所だったが、未対応。
 
-
-### ローカル開発環境で Redis にデータ登録
-
-```
-$ docker-compose exec redis \
-  redis-cli hmset localhost crt "$(cat docker/certs/localhost.crt)" \
-  key "$(cat docker/certs/localhost.key)"
-$ docker-compose exec redis redis-cli hmget localhost crt key
-```
-
 ## MySQL 接続
 
 Userdata に接続情報を渡し、再利用する。
@@ -87,7 +106,7 @@ if mysql != nil then
 end
 ```
 
-* docker/hook/mysql_test.rb
+* examples/mysql.rb
 
 ```
 mysql.execute('select * from certs') do |row, fields|

--- a/crt.sh
+++ b/crt.sh
@@ -4,5 +4,5 @@ readonly DIR=docker/certs
 NAME=$1
 
 openssl genrsa -out ${DIR}/${NAME}.key 4096
-openssl req -new -key ${DIR}/${NAME}.key -out ${DIR}/${NAME}.csr -subj "/CN=${NAME}"
+openssl req -new -key ${DIR}/${NAME}.key -out ${DIR}/${NAME}.csr -subj "/CN=*.${NAME}"
 openssl x509 -req -in ${DIR}/${NAME}.csr -days 36500 -signkey ${DIR}/${NAME}.key > ${DIR}/${NAME}.crt

--- a/dip.yml
+++ b/dip.yml
@@ -1,0 +1,21 @@
+version: '6.1'
+
+compose:
+  files:
+    - docker-compose.yml
+
+interaction:
+  bash:
+    description: Open the Bash shell in nginx's container
+    service: nginx
+    command: bash
+
+  'redis-cli':
+    description: Run Redis console
+    service: redis
+    command: redis-cli -h redis
+
+provision:
+  - sh crt.sh localhost
+  - dip compose up -d redis
+  - dip redis-cli hmset localhost crt "$(cat docker/certs/localhost.crt)" key "$(cat docker/certs/localhost.key)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   nginx:
+    container_name: nginx
     build:
       context: .
       dockerfile: Dockerfile
@@ -9,14 +10,17 @@ services:
       - 80:80
       - 443:443
     environment:
+      DEFAULT_DOMAIN: 'localhost'
       REDIS_HOST: 'redis'
     links:
       - redis:redis
     volumes:
       - ./docker/certs:/etc/ssl/certs
+      - ./docker/hook:/usr/local/nginx/hook
 
   redis:
     image: redis:alpine
+    container_name: redis
     ports:
       - ${REDIS_PORT:-6379}:6379
     volumes:

--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -1,4 +1,5 @@
 env REDIS_HOST;
+env DEFAULT_DOMAIN;
 
 user daemon;
 worker_processes auto;


### PR DESCRIPTION
* 証明書発行スクリプト crt.sh をワイルドカード指定で発行する
* デフォルトのドメイン localhost のサブドメインについて localhost のワイルドカード 証明書でパスできる様にする
* README に開発手順を追記する