### PR TITLE
開発環境用 Nginx 設定ファイルを分離する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ COPY docker/nginx/conf/nginx.conf conf/nginx.conf
 COPY docker/nginx/conf/conf.d/${ENVIRONMENT}.conf conf/conf.d/default.conf
 COPY docker/nginx/hook hook
 
+RUN ln -sf /dev/stdout /etc/nginx/logs/access.log
+
 EXPOSE 80 443
 
 CMD ["/etc/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/docker/nginx/conf/conf.d/development.conf
+++ b/docker/nginx/conf/conf.d/development.conf
@@ -1,5 +1,15 @@
-upstream backend {
-    server minio:9000;
+server {
+    listen 80;
+    server_name _;
+
+    # ELB のヘルスチェッカーの場合、 200 を返す
+    if ($http_user_agent ~* ELB-HealthChecker) {
+        return 200;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {
@@ -14,10 +24,7 @@ server {
     mruby_ssl_handshake_handler /etc/nginx/hook/ssl_handshake_handler.rb cache;
 
     location / {
-        mruby_set $backend /etc/nginx/hook/backend.rb;
-        proxy_pass http://backend/$backend;
-        proxy_intercept_errors on;
-        proxy_redirect     off;
-        break;
+        root /etc/nginx/html;
+        index index.html;
     }
 }

--- a/docker/nginx/conf/nginx.conf
+++ b/docker/nginx/conf/nginx.conf
@@ -48,41 +48,5 @@ http {
     mruby_init_worker /etc/nginx/hook/init_worker.rb;
     mruby_exit_worker /etc/nginx/hook/exit_worker.rb;
 
-    server {
-        listen 80;
-        listen [::]:80;
-        # ELB到達がHTTPだった場合、HTTPにリダイレクトする
-        if ($http_x_forwarded_proto != https) {
-            set $to_https  A;
-        }
-        if ($http_user_agent !~* ELB-HealthChecker) {
-            set $to_https  "${to_https}B";
-        }
-        if ($to_https = AB) {
-            return 301 https://$host$request_uri;
-        }
-
-        location / {
-            if ($request_uri ~ ^/healthcheck) {
-                return 200;
-            }
-        }
-    }
-
-    server {
-        listen 443 ssl;
-        server_name _;
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_prefer_server_ciphers on;
-        ssl_ciphers 'ECDHE+AESGCM:DHE+aRSA+AESGCM:ECDHE+AESCCM:DHE+aRSA+AESCCM:+AES256:ECDHE+CHACHA20:DHE+aRSA+CHACHA20:+DHE:ECDHE+AES128:ECDHE+CAMELLIA128:ECDHE+AES:ECDHE+CAMELLIA:+ECDHE+SHA:DHE+aRSA+AES128:DHE+aRSA+CAMELLIA128:DHE+aRSA+AES:DHE+aRSA+CAMELLIA:+DHE+aRSA+SHA';
-        ssl_certificate /etc/ssl/certs/dummy.crt;
-        ssl_certificate_key /etc/ssl/certs/dummy.key;
-
-        mruby_ssl_handshake_handler /etc/nginx/hook/ssl_handshake_handler.rb cache;
-
-        location / {
-            root /etc/nginx/html;
-            index index.html;
-        }
-    }
+    include /etc/nginx/conf/conf.d/*.conf;
 }

--- a/docker/nginx/hook/exit_worker.rb
+++ b/docker/nginx/hook/exit_worker.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-Userdata.new("redis_#{Process.pid}").client.close
+redis = Userdata.new("redis_#{Process.pid}").redis_connection
+redis&.close


### PR DESCRIPTION
* 開発環境用 Nginx 設定ファイルを分離する

以下の様にビルド引数で ENVIRONMENT に指定する値の Nginx 設定ファイルをビルド時に採用する様にします。

```
docker build --buld-arg ENVIRONMENT=development ...
```

* Nginx アクセスログへ標準出力のシンボリックリンクを設定し、アクセスログを標準出力に出力します。
* worker exit 時に Redis 接続処理を close する