### PR TITLE
開発環境用に example.com 証明書情報を DynamoDB に登録する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Test](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/test.yml/badge.svg)](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/test.yml) [![Lint](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/lint.yml/badge.svg)](https://github.com/kenzo0107/ngx_mruby-ssl-dynamic-delivery/actions/workflows/lint.yml)
 
 ## 本リポジトリの目的
+
 ngx_mruby でローカル環境で動的証明書配信を試験する。
 
 以下論文の p4 にある設定例を参考に検証する。
@@ -19,16 +20,13 @@ ngx_mruby でローカル環境で動的証明書配信を試験する。
 ```console
 dip provision
 ```
-
-開発で使用する `*.localhost` ワイルドカード証明書の localhost.crt, localhost.key を作成し redis に登録します。
-
 ### 3. /etc/hosts 設定
 
 ```console
-echo "127.0.0.1 aaa.localhost bbb.localhost" | sudo tee -a /etc/hosts
+echo "127.0.0.1 aaa.localhost bbb.localhost foo.example.com" | sudo tee -a /etc/hosts
 ```
 
-aaa.localhost, bbb.localhost を 127.0.0.1 に向ける。
+各開発環境で利用するドメインを 127.0.0.1 に向ける。
 
 ### 4. serverの起動
 
@@ -41,3 +39,18 @@ docker-compose up -d
 ```console
 dip test
 ```
+
+## curl でアクセス
+
+```console
+$ curl -k https://aaa.localhost
+aaa.localhost
+
+$ curl -k https://bbb.localhost
+bbb.localhost
+
+$ curl -k https://foo.example.com
+foo.example.com
+```
+
+各ドメインで証明書を動的に読み込みし、ドメイン名を返すことが確認できる。

--- a/dip.yml
+++ b/dip.yml
@@ -22,6 +22,7 @@ interaction:
 
 provision:
   - sh crt.sh localhost
+  - sh crt.sh example.com
 
   # DynamoDB にデータ登録
   - dip compose up -d dynamodb-local
@@ -40,6 +41,12 @@ provision:
       --table-name Certificates \
       --item '{
         "domain": {"S": "*.localhost"},
-        "state": {"N": "1"},
         "crt": {"S": "'"$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' certs/localhost.crt)"'"},
         "key": {"S": "'"$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' certs/localhost.key)"'"} }'
+  - |
+    aws dynamodb put-item --endpoint-url http://localhost:8000 \
+      --table-name Certificates \
+      --item '{
+        "domain": {"S": "foo.example.com"},
+        "crt": {"S": "'"$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' certs/example.com.crt)"'"},
+        "key": {"S": "'"$(awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' certs/example.com.key)"'"} }'


### PR DESCRIPTION
*.localhost の証明書以外に example.com 証明書情報を DynamoDB に登録し、
foo.example.com でアクセスした際に証明書を動的に読み込みできることを確認できる様にします。

README で foo.example.com を 127.0.0.1 に向けることを追記します。
また、 curl で実際にアクセスし、ドメイン名 を返すことを追記しておきます。